### PR TITLE
rgba opacity range

### DIFF
--- a/app/partials/color-picker.html
+++ b/app/partials/color-picker.html
@@ -3,7 +3,7 @@
         <input class=form-control ng-model=color.r label=R class=color-picker type=range/text min=0 max=255 step=1>
         <input class=form-control ng-model=color.g label=G class=color-picker type=range/text min=0 max=255 step=1>
         <input class=form-control ng-model=color.b label=B class=color-picker type=range/text min=0 max=255 step=1>    
-        <input class=form-control ng-model=color.a label=A class=color-picker type=range/text min=0 max=255 step=1>
+        <input class=form-control ng-model=color.a label=A class=color-picker type=range/text min=0 max=1 step=0.1>
         <!-- <input class=form-control ng-model=hex label=Hex class=color-picker type=text min=0 max=255 step=1> -->
     <div class='col-xs-2 color-picker-label'>
         Hex


### PR DESCRIPTION
"A" in RGBA should be in 0-1 range. With current 0-255 range and 1 step, it's invisible at 0 and fully opaque at all other values.

![image](https://cloud.githubusercontent.com/assets/178133/5835749/719e5538-a16c-11e4-82a1-32632fd99542.png)
 (left: 0-255 at 0, center: 0-255 at 1, right: 0-1 at 0.5)