### PR TITLE
Generate smaller CSS files by not rendering needless CSS properties

### DIFF
--- a/app/less/range.less
+++ b/app/less/range.less
@@ -1,4 +1,5 @@
 @thumb-color: #555bc8;
+@thumb-color-alpha: 1;
 @thumb-radius: 8px;
 @thumb-height: 30px;
 @thumb-width: 30px;
@@ -6,113 +7,126 @@
 @thumb-shadow-size: 1px;
 @thumb-shadow-blur: 1px;
 @thumb-shadow-color: #111;
+@thumb-shadow-color-alpha: 1;
 
 @thumb-border-width: 1px;
 @thumb-border-color: white;
+@thumb-border-color-alpha: 1;
 
 @track-width: 100%;
 @track-color: #424242;
+@track-color-alpha: 1;
 @track-height: 10px;
 
 @track-shadow-size: 2px;
 @track-shadow-blur: 2px;
 @track-shadow-color: #222;
+@track-shadow-color-alpha: 1;
 
 @track-border-width: 1px;
 @track-border-color: black;
+@track-border-color-alpha: 1;
 
 @track-radius: 5px;
 @contrast: 5%;
 
-.shadow(@shadow-size,@shadow-blur,@shadow-color) {
-	box-shadow: @shadow-size @shadow-size @shadow-blur @shadow-color, 0px 0px @shadow-size lighten(@shadow-color,5%);
+
+.shadow(@shadow-size,@shadow-blur,@shadow-color, @shadow-alpha) when not (@shadow-alpha = 0){
+  box-shadow: 0 @shadow-size @shadow-blur fade(@shadow-color, @shadow-alpha * 100%), 0 0 @shadow-size lighten(@shadow-color, @contrast);
 }
 
-.track() {
-	width: @track-width;
-	height: @track-height;
-	cursor: pointer;
+.border(@border-width, @border-style, @border-color, @border-color-alpha) when not (@border-width <= 0),(@border-color-alpha = 0){
+  border: @border-width @border-style fade(@border-color, @border-color-alpha * 100%);
+}
+.border(@border-width, @border-style, @border-color, @border-color-alpha) when (@border-width <= 0){
+  border: 0;
 }
 
-.thumb() {
-    .shadow(@thumb-shadow-size,@thumb-shadow-blur,@thumb-shadow-color);
-    border: @thumb-border-width solid @thumb-border-color;
-    height: @thumb-height;
-    width: @thumb-width;
-    border-radius: @thumb-radius;
-    background: @thumb-color;
-    cursor: pointer;
+.border-radius(@radius) when (@radius > 0){
+  border-radius: @radius;
+}
+
+.track(){
+  width: @track-width;
+  height: @track-height;
+  cursor: pointer;
 }
 
 
-input[type=range] {
+.thumb(){
+  width: @thumb-width;
+  height: @thumb-height;
+  background: fade(@thumb-color, @thumb-color-alpha * 100%);
+  .border(@thumb-border-width, solid, @thumb-border-color, @thumb-border-color-alpha);
+  .border-radius(@thumb-radius);
+  cursor: pointer;
+  .shadow(@thumb-shadow-size,@thumb-shadow-blur,@thumb-shadow-color,@thumb-shadow-color-alpha);
+}
+
+
+input[type=range]{
+  width: @track-width;
+  // margin: (@thumb-height - @track-height) * 2 0;
+  margin: (@thumb-height - @track-height) / 2 0;
+
+  -webkit-appearance: none;
+  &:focus{
+    outline: none;
+  }
+  &::-webkit-slider-runnable-track{
+    background: fade(@track-color, @track-color-alpha * 100%);
+    .border(@track-border-width, solid, @track-border-color, @track-border-color-alpha);
+    .border-radius(@track-radius);
+    .track();
+    .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color,@track-shadow-color-alpha);
+  }
+  &::-webkit-slider-thumb{
+    margin-top: (-@track-border-width + @track-height / 2) - (@thumb-height / 2);
+    .thumb();
+
     -webkit-appearance: none;
-    width: @track-width;
-    // margin: (@thumb-height - @track-height) * 2 0;
-    margin: (@thumb-height - @track-height) / 2 0;
-
-    &:focus {
-        outline: none;
-    }
-
-    &::-webkit-slider-runnable-track {
-        .track();
-        .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color);
-        background: @track-color;
-        border-radius: @track-radius;
-        border: @track-border-width solid @track-border-color;
-    }
-    
-    &::-webkit-slider-thumb {
-        .thumb();
-        -webkit-appearance: none;
-        margin-top: (-@track-border-width + @track-height / 2) - (@thumb-height / 2);
-    }
-
-    &:focus::-webkit-slider-runnable-track {
-        background: lighten(@track-color, @contrast);
-    }
-
-    &::-moz-range-track {
-        .track();
-        .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color);
-        background: @track-color;
-        border-radius: @track-radius;
-        border: @track-border-width solid @track-border-color;
-    }
-    &::-moz-range-thumb {
-       .thumb();
-    }
-
-    &::-ms-track {
-        .track(); 
-        background: transparent;
-        border-color: transparent;
-        // border-width: @thumb-width 0;
-        // margin-top: -15px;
-        color: transparent;
-    }
-
-    &::-ms-fill-lower {
-        background: darken(@track-color, @contrast);
-        border: @track-border-width solid @track-border-color;
-        border-radius: @track-radius*2;
-        .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color);
-    }
-    &::-ms-fill-upper {
-        background: @track-color;
-        border: @track-border-width solid @track-border-color;
-        border-radius: @track-radius*2;
-        .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color);
-    }
-    &::-ms-thumb {
-        .thumb();
-        height: min(@track-height,@thumb-height);
-    }
-    &:focus::-ms-fill-lower {
-        background: @track-color;
-    }
-    &:focus::-ms-fill-upper {
-        background: lighten(@track-color, @contrast);
-    }
+  }
+  &:focus::-webkit-slider-runnable-track{
+    background: lighten(@track-color, @contrast);
+  }
+  &::-moz-range-track{
+    background: fade(@track-color, @track-color-alpha * 100%);
+    .border(@track-border-width, solid, @track-border-color, @track-border-color-alpha);
+    .border-radius(@track-radius);
+    .track();
+    .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color,@track-shadow-color-alpha);
+  }
+  &::-moz-range-thumb{
+    .thumb();
+  }
+  &::-ms-track{
+    background: transparent;
+    border-color: transparent;
+    // border-width: @thumb-width 0;
+    // margin-top: -15px;
+    color: transparent;
+    .track();
+  }
+  &::-ms-fill-lower{
+    background: darken(@track-color, @contrast);
+    .border(@track-border-width, solid, @track-border-color, @track-border-color-alpha);
+    .border-radius(@track-radius*2);
+    .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color,@track-shadow-color-alpha);
+  }
+  &::-ms-fill-upper{
+    background: fade(@track-color, @track-color-alpha * 100%);
+    .border(@track-border-width, solid, @track-border-color, @track-border-color-alpha);
+    .border-radius(@track-radius*2);
+    .shadow(@track-shadow-size,@track-shadow-blur,@track-shadow-color,@track-shadow-color-alpha);
+  }
+  &::-ms-thumb{
+    height: min(@track-height,@thumb-height);
+    .thumb();
+  }
+  &:focus::-ms-fill-lower{
+    background: fade(@track-color, @track-color-alpha * 100%);
+  }
+  &:focus::-ms-fill-upper{
+    background: lighten(@track-color, @contrast);
+  }
 }

--- a/app/less/range.less
+++ b/app/less/range.less
@@ -31,7 +31,7 @@
 @contrast: 5%;
 
 
-.shadow(@shadow-size,@shadow-blur,@shadow-color, @shadow-alpha) when not (@shadow-alpha = 0){
+.shadow(@shadow-size,@shadow-blur,@shadow-color, @shadow-alpha) when not (@shadow-alpha >= 0){
   box-shadow: 0 @shadow-size @shadow-blur fade(@shadow-color, @shadow-alpha * 100%), 0 0 @shadow-size lighten(@shadow-color, @contrast);
 }
 

--- a/app/scripts/run.js
+++ b/app/scripts/run.js
@@ -7,17 +7,27 @@ angular.module("DemoApp").run(function ($rootScope, presets, $timeout) {
         var slider = $rootScope.slider;
         var lessVals = angular.copy(slider);
 
-        function toRGBA(rgbObject) {
-            return "rgba(" + parseFloat(rgbObject.r) + "," + parseFloat(rgbObject.g) + "," + parseFloat(rgbObject.b) + "," + parseFloat(rgbObject.a) + ")";
+        function toRGB(rgbaObject) {
+            return "rgb(" + parseFloat(rgbaObject.r) + "," + parseFloat(rgbaObject.g) + "," + parseFloat(rgbaObject.b) + ")";
         }
 
-        lessVals['thumb-color'] = toRGBA(lessVals['thumb-color']);
-        lessVals['thumb-border-color'] = toRGBA(lessVals['thumb-border-color']);
-        lessVals['thumb-shadow-color'] = toRGBA(lessVals['thumb-shadow-color']);
+        function getAlpha(rgbaObject) {
+            return parseFloat(rgbaObject.a);
+        }
 
-        lessVals['track-color'] = toRGBA(lessVals['track-color']);
-        lessVals['track-border-color'] = toRGBA(lessVals['track-border-color']);
-        lessVals['track-shadow-color'] = toRGBA(lessVals['track-shadow-color']);
+        lessVals['thumb-color-alpha'] = getAlpha(lessVals['thumb-color']);
+        lessVals['thumb-color'] = toRGB(lessVals['thumb-color']);
+        lessVals['thumb-border-color-alpha'] = getAlpha(lessVals['thumb-border-color']);
+        lessVals['thumb-border-color'] = toRGB(lessVals['thumb-border-color']);
+        lessVals['thumb-shadow-color-alpha'] = getAlpha(lessVals['thumb-shadow-color']);
+        lessVals['thumb-shadow-color'] = toRGB(lessVals['thumb-shadow-color']);
+
+        lessVals['track-color-alpha'] = getAlpha(lessVals['track-color']);
+        lessVals['track-color'] = toRGB(lessVals['track-color']);
+        lessVals['track-border-color-alpha'] = getAlpha(lessVals['track-border-color']);
+        lessVals['track-border-color'] = toRGB(lessVals['track-border-color']);
+        lessVals['track-shadow-color-alpha'] = getAlpha(lessVals['track-shadow-color']);
+        lessVals['track-shadow-color'] = toRGB(lessVals['track-shadow-color']);
 
         lessVals['track-radius'] += "px";
         lessVals['track-shadow-size'] += "px";

--- a/app/typescript/run.ts
+++ b/app/typescript/run.ts
@@ -6,41 +6,48 @@ angular.module("DemoApp")
 
 	$rootScope.presets = presets;
 
-
-
 	$rootScope.$watch('slider',updateSlider,true);
 
 	function updateSlider(){
 		var slider = $rootScope.slider;
 		var lessVals = angular.copy(slider);
 
-		function toRGBA(rgbObject) {
-			return "rgba("+parseFloat(rgbObject.r)+","+parseFloat(rgbObject.g)+","+parseFloat(rgbObject.b)+","+parseFloat(rgbObject.a)+")";
+    function toRGB(rgbaObject) {
+      return "rgb(" + parseFloat(rgbaObject.r) + "," + parseFloat(rgbaObject.g) + "," + parseFloat(rgbaObject.b) + ")";
+    }
 
-		}
+    function getAlpha(rgbaObject) {
+      return parseFloat(rgbaObject.a);
+    }
 
-		lessVals['thumb-color'] = toRGBA(lessVals['thumb-color']);
-		lessVals['thumb-border-color'] = toRGBA(lessVals['thumb-border-color']);
-		lessVals['thumb-shadow-color'] = toRGBA(lessVals['thumb-shadow-color']);
+    lessVals['thumb-color-alpha'] = getAlpha(lessVals['thumb-color']);
+    lessVals['thumb-color'] = toRGB(lessVals['thumb-color']);
+    lessVals['thumb-border-color-alpha'] = getAlpha(lessVals['thumb-border-color']);
+    lessVals['thumb-border-color'] = toRGB(lessVals['thumb-border-color']);
+    lessVals['thumb-shadow-color-alpha'] = getAlpha(lessVals['thumb-shadow-color']);
+    lessVals['thumb-shadow-color'] = toRGB(lessVals['thumb-shadow-color']);
 
-		lessVals['track-color'] = toRGBA(lessVals['track-color']);
-		lessVals['track-border-color'] = toRGBA(lessVals['track-border-color']);
-		lessVals['track-shadow-color'] = toRGBA(lessVals['track-shadow-color']);
+    lessVals['track-color-alpha'] = getAlpha(lessVals['track-color']);
+    lessVals['track-color'] = toRGB(lessVals['track-color']);
+    lessVals['track-border-color-alpha'] = getAlpha(lessVals['track-border-color']);
+    lessVals['track-border-color'] = toRGB(lessVals['track-border-color']);
+    lessVals['track-shadow-color-alpha'] = getAlpha(lessVals['track-shadow-color']);
+    lessVals['track-shadow-color'] = toRGB(lessVals['track-shadow-color']);
 
-		lessVals['track-radius'] += "px";
-		lessVals['track-shadow-size'] += "px";
-		lessVals['track-shadow-blur'] += "px";
-		lessVals['track-height'] += "px";
-		lessVals['track-border-width'] += "px";
+    lessVals['track-radius'] += "px";
+    lessVals['track-shadow-size'] += "px";
+    lessVals['track-shadow-blur'] += "px";
+    lessVals['track-height'] += "px";
+    lessVals['track-border-width'] += "px";
 
-		lessVals['thumb-shadow-size'] += "px";
-		lessVals['thumb-shadow-blur'] += "px";
-		lessVals['thumb-height'] += "px";
-		lessVals['thumb-width'] += "px";
-		lessVals['thumb-border-width'] += "px";
-		lessVals['thumb-radius'] += "px";
+    lessVals['thumb-shadow-size'] += "px";
+    lessVals['thumb-shadow-blur'] += "px";
+    lessVals['thumb-height'] += "px";
+    lessVals['thumb-width'] += "px";
+    lessVals['thumb-border-width'] += "px";
+    lessVals['thumb-radius'] += "px";
 
-		lessVals['contrast'] += "%";
+    lessVals['contrast'] += "%";
 
 		less.modifyVars(lessVals);
 	}
@@ -128,7 +135,7 @@ angular.module("DemoApp")
 	 //    template:function(tElem,tAttr){
 		// // console.log("templating...",tAttr);
 		// // var tmpl = "";
-		
+
 		// // var div = angular.element("<div>");
 		// // div.append("<input>");
 		// // var input = div.find("input");


### PR DESCRIPTION
Range.css has a LESS-Template for the configurable CSS output which supports many different styling variations - such as box-shadow, borders etc.
In a "normal" project you would go to https://github.com/danielstern/range.css, adjust the sliders, copy your generated CSS and you're ready to go. But in larger projects, where some lines of code can rest for long time while they should be maintainable through all the time. So one would need the LESS file in the first attempt but the smaller the code the better it is for loading performance.
So the LESS template contains box-shadow properties. What if my custom range slider does not have shadows? I wouldn't need these 5 lines of code. Additionally my slider maybe does not have borders - so I could save another 5 lines of generated CSS output.

The change in this case was to split up the lessVars for colors which contained RGBA strings ('@thumb-color', '@thumb-shadow-color', '@thumb-border-color', '@track-color', '@track-shadow-color' and '@track-border-color') into a separate RGB string and the alpha value (e.g. ‘@track-color' and '@track-color-alpha').
This allows us to use conditional statements in our LESS template. You can define a mixin for the box-shadow-property:

``` less
.shadow(@shadow-size, @shadow-blur, @shadow-color, @shadow-alpha) when not (@shadow-alpha >= 0) {
    box-shadow: 0 @shadow-size @shadow-blur fade(@shadow-color, @shadow-color-alpha * 100%);
}
```

When we call this mixin and pass our parameters it will check if the parameter '@shadow-alpha' is bigger or equal 0. When it is not, the property inside gets inserted - when it is, it does nothing.
Because our alpha value is between 0 and 1, we have to multiply it by 100% to match the requirements for the less function ['fade()'](http://lesscss.org/functions/#color-operations-fade) which converts a given color value and an alpha value to rgba().

Given this LESS fragment:

``` less
.thumb {
    width: 100%;
    height: 24px;
    .shadow(3px, 0, 5px, #000, 0.25);
}
```

will generate the following output:

``` css
.thumb {
    width: 100%;
    height: 24px;
    box-shadow: 3px  0 5px rgba(0,0,0, 0.25);
}
```

while when calling:

``` less
.thumb {
    ....
    .shadow(3px, 0, 5px, #000, 0);
}
```

instead, it will generate the following output where the box-shadow-property is missing, because the shadow is not visible:

``` css
.thumb {
    width: 100%;
    height: 24px;
}
```

I know it might seem a lot of stuff for saving maybe 10 lines of generated CSS, but that's why we are frontend devs, right? ;)
