### PR TITLE
Remove white background on Firefox

### DIFF
--- a/app/less/range.less
+++ b/app/less/range.less
@@ -68,6 +68,7 @@ input[type=range]{
   width: @track-width;
   // margin: (@thumb-height - @track-height) * 2 0;
   margin: (@thumb-height - @track-height) / 2 0;
+  background-color: transparent;
 
   -webkit-appearance: none;
   &:focus{


### PR DESCRIPTION
Tested in IE, Pre-Chromium Edge, Chrome and Firefox (Latest versions of each)

Fixes #24 